### PR TITLE
reflecting libraries expectation of path objects instead of strings in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,8 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/README.md
+++ b/README.md
@@ -30,22 +30,25 @@ The library has three main components:
 The `AnnotationSet` class contains static methods to read different databases:
 
 ```python
+from globox import Annotation, AnnotationSet
+from pathlib import Path
+
 # COCO
-coco_gts = AnnotationSet.from_coco(file_path="path/to/file.json")
+coco_gts = AnnotationSet.from_coco(file_path=Path("path/to/file.json"))
 
 # Pascal VOC
-xml_gts = AnnotationSet.from_xml(folder="path/to/files/")
+xml_gts = AnnotationSet.from_xml(folder=Path("path/to/files/"))
 
 # YOLO
 yolo_preds = AnnotationSet.from_yolo(
-    folder="path/to/files/",
-    image_folder="path/to/images/")
+    folder=Path("path/to/files/"),
+    image_folder=Path("path/to/images/"))
 ```
 
 `Annotation` offers file-level granularity for compatible datasets:
 
 ```python
-annotation = Annotation.from_labelme(file_path="path/to/file.xml")
+annotation = Annotation.from_labelme(file_path=Path("path/to/file.xml"))
 ```
 
 For more specific implementations the `BoundingBox` class contains lots of utilities to parse bounding boxes in different formats, like the `create()` method.
@@ -116,14 +119,14 @@ Datasets can be converted to and savde in other formats easily:
 
 ```python
 # To Pascal VOC
-coco_gts.save_xml(save_dir="pascalVOC_db/")
+coco_gts.save_xml(save_dir=Path("pascalVOC_db/"))
 
 # TO CVAT
-coco_gts.save_cvat(path="train.xml")
+coco_gts.save_cvat(path=Path("train.xml"))
 
 # To YOLO
 coco_gts.save_yolo(
-    save_dir="yolo_train/", 
+    save_dir=Path("yolo_train/"), 
     label_to_id={"cat": 0, "dog": 1, "racoon": 2})
 ```
 
@@ -132,6 +135,8 @@ coco_gts.save_yolo(
 Evaluating is as easy as:
 
 ```python
+from globox import COCOEvaluator
+
 evaluator = COCOEvaluator(coco_gts, yolo_preds)
 ap = evaluator.ap()
 ```
@@ -173,7 +178,7 @@ which outputs:
 The array of results can be saved in CSV format:
 
 ```python
-evaluator.save_csv("where/to/save/results.csv")
+evaluator.save_csv(Path("where/to/save/results.csv"))
 ```
 
 Custom evaluations can be achieved with:


### PR DESCRIPTION
Hi Louis,

first off, great work, just what I was looking for after reading Rafael Padilla's paper on object-detection metrics and playing around with his GUI application. 
While using your package, to calculate the coco metrics, I ran into the issue of having to use the `Path` object instead of just writing out the paths as strings, as I am used to from other packages. Not a big deal since looking at your code, you make good use of all the built-in methods of the `Path` object.
Still, to make it a little clearer to first-time users, I added `Path()` calls to the readme.

While typing this, a thought just came to my mind: maybe you could use a decorator to convert string paths into `Path` objects, without adding a high amounts of boilerplate code into every function.