### PR TITLE
use conf_last=True in from_yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ xml_gts = AnnotationSet.from_xml(folder="path/to/files/")
 # YOLO
 yolo_preds = AnnotationSet.from_yolo(
     folder="path/to/files/",
-    image_folder="path/to/images/"
+    image_folder="path/to/images/",
+    conf_last=True
 )
 ```
 

--- a/src/globox/annotationset.py
+++ b/src/globox/annotationset.py
@@ -204,7 +204,7 @@ class AnnotationSet:
         folder: PathLike, *,
         image_folder: Optional[PathLike] = None, 
         image_extension = ".jpg",
-        conf_last: bool = False,
+        conf_last: bool = True,
         verbose: bool = False
     ) -> "AnnotationSet":
         return AnnotationSet.from_txt(folder, 


### PR DESCRIPTION
[The default format of yolov5 predictions](https://github.com/ultralytics/yolov5/blob/9bc60349b62500096832d78989336fcda200d286/detect.py#L164)  puts confidence at the end of the line. globox will be more compatible with the convenient yolo-format text files if set `conf_last=True`. 

Also adding an example of using `conf_last` in README can notify others who don't know about this `globox.AnnotationSet.from_yolo` argument.