### PR TITLE
Allowing string ids inside coco format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,8 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/src/globox/annotationset.py
+++ b/src/globox/annotationset.py
@@ -290,19 +290,19 @@ class AnnotationSet:
             content = json.load(f)
 
         id_to_label = {
-            int(d["id"]): str(d["name"]) 
+            d["id"]: str(d["name"]) 
             for d in content["categories"]
         }
         
         id_to_annotation = {
-            int(d["id"]): Annotation._from_coco_partial(d)
+            d["id"]: Annotation._from_coco_partial(d)
             for d in content["images"]
         }
         
         elements = content["annotations"]
         
         for element in tqdm(elements, desc="Parsing", disable=not verbose):
-            annotation = id_to_annotation[int(element["image_id"])]
+            annotation = id_to_annotation[element["image_id"]]
             label = id_to_label[int(element["category_id"])]
             coords = tuple(float(c) for c in element["bbox"])
             confidence = element.get("score")

--- a/src/globox/annotationset.py
+++ b/src/globox/annotationset.py
@@ -6,7 +6,7 @@ from .image_utils import get_image_size
 from .atomic import open_atomic
 from .thread_utils import thread_map
 
-from typing import Dict, Callable, Iterator, Mapping, TypeVar, Iterable, Union, Optional
+from typing import Dict, Callable, Iterator, Mapping, TypeVar, Iterable, Union, Optional, Any
 import csv
 from pathlib import Path
 import xml.etree.ElementTree as et
@@ -40,8 +40,8 @@ class AnnotationSet:
             for annotation in annotations:
                 self.add(annotation, override=override)
 
-        self._id_to_label: Optional["dict[int, str]"] = None
-        self._id_to_imageid: Optional["dict[int, str]"] = None
+        self._id_to_label: Optional["dict[Any, str]"] = None
+        self._id_to_imageid: Optional["dict[Any, str]"] = None
 
     def __getitem__(self, image_id: str) -> Annotation:
         return self._annotations[image_id]

--- a/src/globox/boundingbox.py
+++ b/src/globox/boundingbox.py
@@ -446,5 +446,16 @@ class BoundingBox:
             "region_attributes": region_attributes
         }
 
+    def __eq__(self, other):
+        if isinstance(other, BoundingBox):
+            if self.label == other.label \
+                    and self.xmin == other.xmin \
+                    and self.ymin == other.ymin \
+                    and self.xmax == other.xmax \
+                    and self.ymax == other.ymax:
+                return True
+        return False
+
+
     def __repr__(self) -> str:
         return f"BoundingBox(label: {self.label}, xmin: {self._xmin}, ymin: {self._ymin}, xmax: {self._xmax}, ymax: {self._ymax}, confidence: {self._confidence})"

--- a/src/globox/boundingbox.py
+++ b/src/globox/boundingbox.py
@@ -447,15 +447,17 @@ class BoundingBox:
         }
 
     def __eq__(self, other):
-        if isinstance(other, BoundingBox):
-            if self.label == other.label \
-                    and self.xmin == other.xmin \
-                    and self.ymin == other.ymin \
-                    and self.xmax == other.xmax \
-                    and self.ymax == other.ymax:
-                return True
-        return False
-
+        if not isinstance(other, BoundingBox):
+            raise NotImplementedError
+        
+        return (
+            self.label == other.label
+            and self.xmin == other.xmin
+            and self.ymin == other.ymin
+            and self.xmax == other.xmax
+            and self.ymax == other.ymax
+            and self.confidence == other.confidence
+        )
 
     def __repr__(self) -> str:
         return f"BoundingBox(label: {self.label}, xmin: {self._xmin}, ymin: {self._ymin}, xmax: {self._xmax}, ymax: {self._ymax}, confidence: {self._confidence})"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -8,7 +8,7 @@ dets_path = data_path / "dets/"
 image_folder = data_path / "images/"
 names_file = gts_path / "yolo_format/obj.names"
 
-coco_str_id_path = gts_path / "coco_format_str_id/test.json"
+coco_str_id_path = gts_path / "coco_format_v3/instances_v3.json"
 coco1_path = gts_path / "coco_format_v1/instances_default.json"
 coco2_path = gts_path / "coco_format_v2/instances_v2.json"
 coco_gts_path = data_path / "coco_eval/ground_truths.json"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -8,6 +8,7 @@ dets_path = data_path / "dets/"
 image_folder = data_path / "images/"
 names_file = gts_path / "yolo_format/obj.names"
 
+coco_str_id_path = gts_path / "coco_format_str_id/test.json"
 coco1_path = gts_path / "coco_format_v1/instances_default.json"
 coco2_path = gts_path / "coco_format_v2/instances_v2.json"
 coco_gts_path = data_path / "coco_eval/ground_truths.json"

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -27,7 +27,7 @@ def test_image_size():
         _ = Annotation(image_id="_a", image_size=(-1, 10))
 
     with pytest.raises(AssertionError):
-        _ = Annotation(image_id="_a", image_size=(10, 10.0))  # type: ignore
+        _ = Annotation(image_id="_a", image_size=(10, 10.2))  # type: ignore
 
 
 def test_map_labels():

--- a/tests/test_annotationset.py
+++ b/tests/test_annotationset.py
@@ -172,11 +172,15 @@ def test_from_txt_conf_last(tmp_path: Path):
     box = annotation.boxes[0]
     assert box.confidence == 0.25
 
-def test_from_coco_id_string(tmp_path: Path):
+
+def test_from_coco_id_string():
     gts = AnnotationSet.from_coco(coco_str_id_path)
+    
     assert len(gts) == 100 # images defined in coco_file
     assert gts["2007_001585.jpg"] is not None
+    
     gts_box = gts["2007_001585.jpg"].boxes[0]
+    
     coco_box = BoundingBox(
         label="bottle", 
         xmin=58.0,
@@ -184,4 +188,5 @@ def test_from_coco_id_string(tmp_path: Path):
         xmax=58.0 + 14.0,
         ymax=158 + 33.0
     )
+    
     assert gts_box == coco_box

--- a/tests/test_annotationset.py
+++ b/tests/test_annotationset.py
@@ -174,14 +174,14 @@ def test_from_txt_conf_last(tmp_path: Path):
 
 def test_from_coco_id_string(tmp_path: Path):
     gts = AnnotationSet.from_coco(coco_str_id_path)
-    assert len(gts) == 190 # images defined in coco_file
-    assert gts["8715817020470_4_ucb.jpg"] is not None
-    gts_box = gts["8715817020470_4_ucb.jpg"].boxes[0]
+    assert len(gts) == 100 # images defined in coco_file
+    assert gts["2007_001585.jpg"] is not None
+    gts_box = gts["2007_001585.jpg"].boxes[0]
     coco_box = BoundingBox(
-        label="market_name", 
-        xmin=float(1784), 
-        ymin=float(2348), 
-        xmax=float(1784 + 360), 
-        ymax=float(2348 + 124)
+        label="bottle", 
+        xmin=58.0,
+        ymin=158.0,
+        xmax=58.0 + 14.0,
+        ymax=158 + 33.0
     )
     assert gts_box == coco_box

--- a/tests/test_annotationset.py
+++ b/tests/test_annotationset.py
@@ -171,3 +171,17 @@ def test_from_txt_conf_last(tmp_path: Path):
     
     box = annotation.boxes[0]
     assert box.confidence == 0.25
+
+def test_from_coco_id_string(tmp_path: Path):
+    gts = AnnotationSet.from_coco(coco_str_id_path)
+    assert len(gts) == 190 # images defined in coco_file
+    assert gts["8715817020470_4_ucb.jpg"] is not None
+    gts_box = gts["8715817020470_4_ucb.jpg"].boxes[0]
+    coco_box = BoundingBox(
+        label="market_name", 
+        xmin=float(1784), 
+        ymin=float(2348), 
+        xmax=float(1784 + 360), 
+        ymax=float(2348 + 124)
+    )
+    assert gts_box == coco_box

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -149,3 +149,78 @@ def test_from_txt_conf_last():
     line = "label 0.25 10 20 30 40"
     box = BoundingBox.from_txt(line)
     assert box.confidence == 0.25
+    
+    
+def test_eq():
+    box = BoundingBox(
+        label="image_0.jpg",
+        xmin=1.0,
+        ymin=2.0,
+        xmax=4.0,
+        ymax=8.0,
+        confidence=0.5
+    )
+    
+    # Same
+    b1 = BoundingBox(
+        label="image_0.jpg",
+        xmin=1.0,
+        ymin=2.0,
+        xmax=4.0,
+        ymax=8.0,
+        confidence=0.5
+    )
+    
+    assert box == b1
+    
+    # Different label
+    b2 = BoundingBox(
+        label="image_1.jpg",
+        xmin=1.0,
+        ymin=2.0,
+        xmax=4.0,
+        ymax=8.0,
+        confidence=0.5
+    )
+    
+    assert box != b2
+    
+    # Different coords
+    b3 = BoundingBox(
+        label="image_0.jpg",
+        xmin=0.0,
+        ymin=2.0,
+        xmax=4.0,
+        ymax=8.0,
+        confidence=0.5
+    )
+    
+    assert box != b3
+    
+    # Different confidence
+    b4 = BoundingBox(
+        label="image_0.jpg",
+        xmin=1.0,
+        ymin=2.0,
+        xmax=4.0,
+        ymax=8.0,
+        confidence=0.25
+    )
+    
+    assert box != b4
+    
+    # No confidence
+    b5 = BoundingBox(
+        label="image_0.jpg",
+        xmin=1.0,
+        ymin=2.0,
+        xmax=4.0,
+        ymax=8.0,
+        confidence=None
+    )
+    
+    assert box != b5
+    
+    # Different object
+    with pytest.raises(NotImplementedError):
+        _ = box == "Different object"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -6,6 +6,7 @@ from .constants import *
 def tests_parsing():
     coco1_set = AnnotationSet.from_coco(coco1_path)
     coco2_set = AnnotationSet.from_coco(coco2_path)
+    coco3_set = AnnotationSet.from_coco(coco_str_id_path)
     coco_gts_set = AnnotationSet.from_coco(coco_gts_path)
     yolo_set = AnnotationSet.from_yolo(yolo_path, image_folder=image_folder).map_labels(id_to_label)
     cvat_set = AnnotationSet.from_cvat(cvat_path)
@@ -20,7 +21,7 @@ def tests_parsing():
     _ = coco_gts_set.from_results(coco_results_path)
 
     dets_sets = [abs_ltrb_set, abs_ltwh_set, rel_ltwh_set]
-    gts_sets = [coco1_set, coco2_set, yolo_set, cvat_set, imagenet_set, labelme_set, openimage_set, pascal_set]
+    gts_sets = [coco1_set, coco2_set, coco3_set, yolo_set, cvat_set, imagenet_set, labelme_set, openimage_set, pascal_set]
     all_sets = dets_sets + gts_sets
 
     assert all_equal(s.image_ids for s in gts_sets)


### PR DESCRIPTION
Hi Louis,

the pascal-voc to coco I've been using uses the image's name as ids all over the place. I might switch to your implementation for transforming pascal-voc to coco in the future, but for now, you could maybe ease the enforcement on int ids. I'm not aware of a formal definition which defines the datatype a value has inside coco has to be. I've been using the same coco files with pycocoapi and received no error.

I've also added a file to your test-data repository, should I open another PR there? If not, here's the link for the test.json -> https://pastebin.com/5v4rwQaq.