### PR TITLE
Remove is_ground_truth and is_detection properties

### DIFF
--- a/src/globox/annotationset.py
+++ b/src/globox/annotationset.py
@@ -654,7 +654,7 @@ class AnnotationSet:
                     "id": ann_id_count
                 }
 
-                if box.is_detection:
+                if box.confidence is not None:
                     box_annotation["score"] = box.confidence
 
                 annotations.append(box_annotation)

--- a/src/globox/boundingbox.py
+++ b/src/globox/boundingbox.py
@@ -168,14 +168,6 @@ class BoundingBox:
 
         return intersection / union
 
-    @property
-    def is_detection(self) -> bool:
-        return self._confidence is not None
-
-    @property
-    def is_ground_truth(self) -> bool:
-        return self._confidence is None
-
     @staticmethod
     def rel_to_abs(coords: Coordinates, size: "tuple[int, int]") -> Coordinates:
         a, b, c, d = coords
@@ -417,7 +409,7 @@ class BoundingBox:
         if isinstance(label, str):
             assert separator not in label, f"The box label '{label}' contains the character '{separator}' which is the same as the separtor character used for BoundingBox representation in TXT/YOLO format. This will corrupt the saved annotation file and likely make it unreadable. Use another character in the label name or `label_to_id` mapping, e.g. use and underscore instead of a whitespace."
 
-        if self.is_ground_truth:
+        if self._confidence is not None:
             line = (label, *coords)
         elif conf_last:
             line = (label, *coords, self._confidence)

--- a/src/globox/boundingbox.py
+++ b/src/globox/boundingbox.py
@@ -409,7 +409,7 @@ class BoundingBox:
         if isinstance(label, str):
             assert separator not in label, f"The box label '{label}' contains the character '{separator}' which is the same as the separtor character used for BoundingBox representation in TXT/YOLO format. This will corrupt the saved annotation file and likely make it unreadable. Use another character in the label name or `label_to_id` mapping, e.g. use and underscore instead of a whitespace."
 
-        if self._confidence is not None:
+        if self._confidence is None:
             line = (label, *coords)
         elif conf_last:
             line = (label, *coords, self._confidence)

--- a/src/globox/evaluation.py
+++ b/src/globox/evaluation.py
@@ -418,7 +418,7 @@ class COCOEvaluator:
 
         cls._assert_params(iou_threshold, max_detections, size_range)
 
-        dets = sorted(predictions, key=lambda box: box._confidence if box._confidence is not None else 0, reverse=True)  # type: ignore
+        dets = sorted(predictions, key=lambda box: box._confidence if box._confidence is not None else -float("inf"), reverse=True)  # if no confidence provided, set to lowest priority
         dets = dets[:max_detections]
 
         gts = sorted(ground_truths, key=lambda box: not box.area_in(size_range))

--- a/src/globox/evaluation.py
+++ b/src/globox/evaluation.py
@@ -413,8 +413,6 @@ class COCOEvaluator:
         max_detections: int,
         size_range: "tuple[float, float]"
     ) -> PartialEvaluationItem:
-        assert all(p.is_detection for p in predictions)
-        assert all(g.is_ground_truth for g in ground_truths)
         assert all_equal(p.label for p in predictions)
         assert all_equal(g.label for g in ground_truths)
 

--- a/src/globox/evaluation.py
+++ b/src/globox/evaluation.py
@@ -418,7 +418,7 @@ class COCOEvaluator:
 
         cls._assert_params(iou_threshold, max_detections, size_range)
 
-        dets = sorted(predictions, key=lambda box: box._confidence, reverse=True)  # type: ignore
+        dets = sorted(predictions, key=lambda box: box._confidence if box._confidence is not None else 0, reverse=True)  # type: ignore
         dets = dets[:max_detections]
 
         gts = sorted(ground_truths, key=lambda box: not box.area_in(size_range))

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -30,7 +30,6 @@ def test_init():
     assert box.width == 2.0
     assert box.height == 2.0
     assert box.area == 4.0
-    assert box.is_ground_truth
 
     assert box.ltrb == (-1, 0, 1, 2)
     assert box.ltwh == (-1, 0, 2, 2)
@@ -40,7 +39,6 @@ def test_init():
 def test_confidence():
     box = BoundingBox(label="", xmin=0, ymin=0, xmax=0, ymax=0, confidence=0.25)
     assert box.confidence == 0.25
-    assert box.is_detection
 
     box = BoundingBox(label="", xmin=0, ymin=0, xmax=0, ymax=0, confidence=0.0)
     assert box.confidence == 0.0
@@ -50,7 +48,6 @@ def test_confidence():
 
     box = BoundingBox(label="", xmin=0, ymin=0, xmax=0, ymax=0)
     assert box.confidence is None
-    assert box.is_ground_truth
 
 
 def test_iou():

--- a/tests/test_coco_evaluation.py
+++ b/tests/test_coco_evaluation.py
@@ -30,3 +30,16 @@ def test_evaluation():
     assert isclose(evaluator.ar_large(), 0.553744, abs_tol=1e-6)
 
     assert evaluator.evaluate.cache_info().currsize == 60
+
+
+def test_evaluation_no_confidence():
+    coco_gt = AnnotationSet.from_coco(coco_gts_path)
+
+    COCOEvaluator(
+        ground_truths=coco_gt, 
+        predictions=coco_gt,
+    ).evaluate(
+        iou_threshold=0.5,
+        max_detections=100,
+        size_range=COCOEvaluator.ALL_RANGE
+    )

--- a/tests/test_coco_evaluation.py
+++ b/tests/test_coco_evaluation.py
@@ -50,3 +50,36 @@ def test_evaluation_no_confidence():
 
 def test_evaluate_defaults(evaluator: COCOEvaluator):
     evaluator.evaluate(iou_threshold=0.6)
+
+
+def test_evaluator_no_confidence_invariance_to_bboxes_order():
+    from globox import AnnotationSet, Annotation, BoundingBox
+    
+    gts = AnnotationSet(annotations=[
+        Annotation("img_1", image_size=(100, 100), boxes=[
+            BoundingBox(label="cat", xmin=0, ymin=0, xmax=3, ymax=3),
+            BoundingBox(label="cat", xmin=1, ymin=0, xmax=4, ymax=3),
+        ])
+    ])
+    
+    dets_1 = AnnotationSet(annotations=[
+        Annotation("img_1", image_size=(100, 100), boxes=[
+            BoundingBox(label="cat", xmin=-1, ymin=0, xmax=2, ymax=3),
+            BoundingBox(label="cat", xmin=0, ymin=0, xmax=3, ymax=3),
+        ])
+    ])
+    
+    dets_2 = AnnotationSet(annotations=[
+        Annotation("img_1", image_size=(100, 100), boxes=[
+            BoundingBox(label="cat", xmin=0, ymin=0, xmax=3, ymax=3),
+            BoundingBox(label="cat", xmin=-1, ymin=0, xmax=2, ymax=3),
+        ])
+    ])
+    
+    evaluator_1 = COCOEvaluator(ground_truths=gts, predictions=dets_1)
+    ap_1 = evaluator_1.ap_50()
+    
+    evaluator_2 = COCOEvaluator(ground_truths=gts, predictions=dets_2)
+    ap_2 = evaluator_2.ap_50()
+    
+    assert isclose(ap_1, ap_2)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -5,22 +5,8 @@
 # Test AP computation
 
 from globox import *
-from .constants import *
 import pytest
 
 
 def test_evaluation_item():
     ...
-
-
-def test_evaluation_no_confidence():
-    coco_gt = AnnotationSet.from_coco(coco_gts_path)
-
-    evaluator = COCOEvaluator(
-        ground_truths=coco_gt, 
-        predictions=coco_gt,
-    ).evaluate(
-        iou_threshold=0.5,
-        max_detections=100,
-        size_range=COCOEvaluator.ALL_RANGE
-    )

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -5,8 +5,22 @@
 # Test AP computation
 
 from globox import *
+from .constants import *
 import pytest
 
 
 def test_evaluation_item():
     ...
+
+
+def test_evaluation_no_confidence():
+    coco_gt = AnnotationSet.from_coco(coco_gts_path)
+
+    evaluator = COCOEvaluator(
+        ground_truths=coco_gt, 
+        predictions=coco_gt,
+    ).evaluate(
+        iou_threshold=0.5,
+        max_detections=100,
+        size_range=COCOEvaluator.ALL_RANGE
+    )


### PR DESCRIPTION
The current `BoundingBox` class has properties `is_ground_truth` and `is_detection` that are basically just aliases for `self.confidence is None` and `self.confidence is not None` respectively. Some models may not produce confidence scores, which then causes issues during `evaluate_boxes` in `evaluation.py`. I could add fake confidence values when creating the detection `AnnotationSet`, but I think it would be better to not mandate users to provide confidence values.

I have tested locally and everything passes. You may want to consider altering the GitHub action to automate tests on pull requests? I can open this up as a separate PR.