### PR TITLE
Add default values to COCOEvaluator.evaluate kwargs

### DIFF
--- a/src/globox/evaluation.py
+++ b/src/globox/evaluation.py
@@ -232,8 +232,8 @@ class COCOEvaluator:
     @lru_cache(maxsize=60 * 4)  # Enough room for 4 times all standard metrics
     def evaluate(self, *,
         iou_threshold: float,
-        max_detections: int,
-        size_range: "tuple[float, float]"
+        max_detections: int = 100,
+        size_range: Optional["tuple[float, float]"] = None,
     ) -> Evaluation:
         """COCO evaluation with custom parameters. The result
         is cached so that repeated call as fast.
@@ -250,8 +250,11 @@ class COCOEvaluator:
         Returns:
         - An evaluation holding the metrics.
         """
+        if size_range is None:
+            size_range = COCOEvaluator.ALL_RANGE
+
         self._assert_params(iou_threshold, max_detections, size_range)
-        
+
         return self.evaluate_annotations(
             self._predictions, 
             self._ground_truths,

--- a/tests/test_coco_evaluation.py
+++ b/tests/test_coco_evaluation.py
@@ -1,17 +1,21 @@
 from globox import COCOEvaluator
 from .constants import *
 from math import isclose
+import pytest
 
 
-def test_evaluation():
+@pytest.fixture
+def evaluator():
     coco_gt = AnnotationSet.from_coco(coco_gts_path)
     coco_det = coco_gt.from_results(coco_results_path)
 
-    evaluator = COCOEvaluator(
+    return COCOEvaluator(
         ground_truths=coco_gt, 
         predictions=coco_det,
     )
 
+
+def test_evaluation(evaluator):
     # Official figures returned by pycocotools (see pycocotools_results.py)
     assert isclose(evaluator.ap(), 0.503647, abs_tol=1e-6)
     assert isclose(evaluator.ap_50(), 0.696973, abs_tol=1e-6)
@@ -30,3 +34,7 @@ def test_evaluation():
     assert isclose(evaluator.ar_large(), 0.553744, abs_tol=1e-6)
 
     assert evaluator.evaluate.cache_info().currsize == 60
+
+
+def test_evaluate_defaults(evaluator):
+    evaluator.evaluate(iou_threshold=0.6)


### PR DESCRIPTION
The docstring for `COCOEvaluator.evaluate` states that `max_detections` has a default value of 100 and `size_range` defaults to `COCOEvaluator.ALL_RANGE`. These defaults are not currently implemented. This PR provides the defaults stated in the original docstring along with a test case.