### PR TITLE
Arbitrary whitespace parsing for TXT and YOLO

### DIFF
--- a/src/globox/annotation.py
+++ b/src/globox/annotation.py
@@ -104,7 +104,7 @@ class Annotation:
         box_format: BoxFormat = BoxFormat.LTRB,
         relative: bool = False,
         image_size: Optional["tuple[int, int]"] = None,
-        separator: str | None = None,
+        separator: Optional[str] = None,
         conf_last: bool = False,
     ) -> "Annotation":
         path = Path(file_path).expanduser().resolve()

--- a/src/globox/annotation.py
+++ b/src/globox/annotation.py
@@ -104,7 +104,7 @@ class Annotation:
         box_format: BoxFormat = BoxFormat.LTRB,
         relative: bool = False,
         image_size: Optional["tuple[int, int]"] = None,
-        separator: str = " ",
+        separator: str | None = None,
         conf_last: bool = False,
     ) -> "Annotation":
         path = Path(file_path).expanduser().resolve()
@@ -153,7 +153,7 @@ class Annotation:
             box_format=BoxFormat.XYWH,
             relative=True,
             image_size=image_size,
-            separator=" ",
+            separator=None,
             conf_last=conf_last,
         )
 

--- a/src/globox/annotationset.py
+++ b/src/globox/annotationset.py
@@ -203,7 +203,7 @@ class AnnotationSet:
         relative=False,
         file_extension: str = ".txt",
         image_extension: str = ".jpg",
-        separator: str | None = None,
+        separator: Optional[str] = None,
         conf_last: bool = False,
         verbose: bool = False,
     ) -> "AnnotationSet":

--- a/src/globox/annotationset.py
+++ b/src/globox/annotationset.py
@@ -203,7 +203,7 @@ class AnnotationSet:
         relative=False,
         file_extension: str = ".txt",
         image_extension: str = ".jpg",
-        separator: str = " ",
+        separator: str | None = None,
         conf_last: bool = False,
         verbose: bool = False,
     ) -> "AnnotationSet":
@@ -286,6 +286,7 @@ class AnnotationSet:
             box_format=BoxFormat.XYWH,
             relative=True,
             image_extension=image_extension,
+            separator=None,
             conf_last=conf_last,
             verbose=verbose,
         )

--- a/src/globox/boundingbox.py
+++ b/src/globox/boundingbox.py
@@ -336,7 +336,7 @@ class BoundingBox:
         box_format=BoxFormat.LTRB,
         relative=False,
         image_size: Optional["tuple[int, int]"] = None,
-        separator: str | None = None,
+        separator: Optional[str] = None,
         conf_last: bool = False,
     ) -> "BoundingBox":
         values = string.strip().split(separator)

--- a/src/globox/boundingbox.py
+++ b/src/globox/boundingbox.py
@@ -336,7 +336,7 @@ class BoundingBox:
         box_format=BoxFormat.LTRB,
         relative=False,
         image_size: Optional["tuple[int, int]"] = None,
-        separator: str = " ",
+        separator: str | None = None,
         conf_last: bool = False,
     ) -> "BoundingBox":
         values = string.strip().split(separator)
@@ -377,7 +377,7 @@ class BoundingBox:
             box_format=BoxFormat.XYWH,
             relative=True,
             image_size=image_size,
-            separator=" ",
+            separator=None,
             conf_last=conf_last,
         )
 

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -169,6 +169,16 @@ def test_from_txt_conf_last():
     assert box.confidence == 0.25
 
 
+def test_from_txt_tab_sep():
+    line = "label\t10\t20\t30\t40\t0.25"
+    box = BoundingBox.from_txt(line, conf_last=True)
+    assert box.confidence == 0.25
+
+    line = "label 0.25 10 20 30 40"
+    box = BoundingBox.from_txt(line)
+    assert box.confidence == 0.25
+
+
 def test_from_yolo_v5():
     line = "label 0.25 0.25 0.5 0.5 0.25"
     bbox = BoundingBox.from_yolo_v5(line, image_size=(100, 100))
@@ -188,6 +198,23 @@ def test_from_yolo_v5():
 
 def test_from_yolo_v7():
     line = "label 0.25 0.25 0.5 0.5 0.25"
+    bbox = BoundingBox.from_yolo_v7(line, image_size=(100, 100))
+
+    assert bbox.label == "label"
+    assert bbox.confidence == 0.25
+
+    (xmin, ymin, xmax, ymax) = bbox.ltrb
+
+    assert isclose(xmin, 0.0)
+    assert isclose(ymin, 0.0)
+    assert isclose(xmax, 50.0)
+    assert isclose(ymax, 50.0)
+
+    assert isclose(bbox.confidence, 0.25)
+
+
+def test_from_yolo_v7_tab_sep():
+    line = "label 0.25\t0.25\t0.5\t0.5\t0.25"
     bbox = BoundingBox.from_yolo_v7(line, image_size=(100, 100))
 
     assert bbox.label == "label"


### PR DESCRIPTION
Added support for arbitrary whitespaces (tabs, etc.) for parsing TXT and YOLO formats.