### PR TITLE
Add missing f-string to BoundingBox __repr__

### DIFF
--- a/src/globox/boundingbox.py
+++ b/src/globox/boundingbox.py
@@ -646,5 +646,5 @@ class BoundingBox:
     def __repr__(self) -> str:
         return (
             f"BoundingBox(label: {self.label}, xmin: {self._xmin}, ymin: {self._ymin}, "
-            "xmax: {self._xmax}, ymax: {self._ymax}, confidence: {self._confidence})"
+            f"xmax: {self._xmax}, ymax: {self._ymax}, confidence: {self._confidence})"
         )


### PR DESCRIPTION
The `BoundingBox` `__repr__` method is currently missing the f-string syntax, causing `BoundingBox`es to be printed like:

```
BoundingBox(..., xmax: {self._xmax}, ymax: {self._ymax}, confidence: {self._confidence})
```

This PR adds in the f-string syntax so that the `__repr__` displays correctly.