### PR TITLE
Add missing f-string to Annotation __repr__

### DIFF
--- a/src/globox/annotation.py
+++ b/src/globox/annotation.py
@@ -636,5 +636,5 @@ class Annotation:
     def __repr__(self) -> str:
         return (
             f"Annotation(image_id: {self.image_id}, image_size: {self.image_size}, "
-            "boxes: {self.boxes})"
+            f"boxes: {self.boxes})"
         )


### PR DESCRIPTION
The `Annotation ` `__repr__` method is currently missing the f-string syntax, causing `Annotation`s to be printed like:

```
Annotation(..., boxes: {self.boxes})
```

This PR adds in the f-string syntax so that the `__repr__` displays correctly.