### PR TITLE
Fix wrong CLI argument name in dets parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "globox"
-version = "2.4.4"
+version = "2.4.5"
 authors = ["Louis Lac <lac.louis5@gmail.com>"]
 license = "MIT"
 packages = [{include = "globox", from = "src"}]

--- a/src/globox/cli.py
+++ b/src/globox/cli.py
@@ -186,7 +186,7 @@ def parse_annotations(args: argparse.Namespace) -> AnnotationSet:
             )
         elif format_in == "txt":
             format = BoxFormat.from_string(args.bb_fmt_in)
-            relative: bool = args.norm_in_dets == "rel"
+            relative: bool = args.norm_in == "rel"
             extension: str = args.ext_in
             sep: str = args.sep_in
 
@@ -265,7 +265,7 @@ def parse_dets_annotations(
             )
         elif format_dets == "txt":
             bb_fmt = BoxFormat.from_string(args.bb_fmt_dets)
-            relative: bool = args.norm_dets == "rel"
+            relative: bool = args.norm_in_dets == "rel"
             extension: str = args.ext_dets
             sep: str = args.sep_dets
 


### PR DESCRIPTION
Fixed the norm dets argument for detections parsing.