### PR TITLE
Annotation `image_id` mapping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,9 @@
       "editor.defaultFormatter": "charliermarsh.ruff",
     },
     "notebook.formatOnSave.enabled": false,
+    "python.testing.pytestArgs": [
+      "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
   }

--- a/src/globox/annotation.py
+++ b/src/globox/annotation.py
@@ -95,6 +95,13 @@ class Annotation:
         """The set of the different label names present in the annotation."""
         return {b.label for b in self.boxes}
 
+    def with_image_id(self, id: str) -> "Annotation":
+        """
+        Create a copy of the current annotation with the provided image id. The image size and
+        bounding boxes are kept unchanged.
+        """
+        return Annotation(image_id=id, image_size=self.image_size, boxes=self.boxes)
+
     @staticmethod
     def from_txt(
         file_path: PathLike,


### PR DESCRIPTION
Allow cloning an annotation giving it a new `image_id` property.